### PR TITLE
cambio en el icono de Twitter

### DIFF
--- a/src/components/FaIcon/FaIcon.js
+++ b/src/components/FaIcon/FaIcon.js
@@ -1,22 +1,28 @@
 import React from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEnvelope, faLocationDot } from "@fortawesome/free-solid-svg-icons"
-import { faLinkedin, faTwitter, faInstagram, faYoutube, faSpotify } from "@fortawesome/free-brands-svg-icons"
+import {
+  faLinkedin,
+  faInstagram,
+  faYoutube,
+  faSpotify,
+  faXTwitter, 
+} from "@fortawesome/free-brands-svg-icons"
 import PropTypes from "prop-types"
 
-// Mapeo de los íconos que se usan
 const iconMap = {
   "fa-envelope": faEnvelope,
   "fa-location-dot": faLocationDot,
   "fa-linkedin": faLinkedin,
-  "fa-twitter": faTwitter,
+  "fa-x-twitter": faXTwitter, 
   "fa-instagram": faInstagram,
   "fa-youtube": faYoutube,
   "fa-spotify": faSpotify,
 }
 
 const FaIcon = ({ type, code }) => {
-  const icon = iconMap[code]
+  const normalizedCode = code?.toLowerCase()
+  const icon = iconMap[normalizedCode]
 
   if (!icon) {
     console.warn(`Icono no encontrado: type=${type}, code=${code}`)

--- a/src/components/Footer/SocialLinks/socialLinks.js
+++ b/src/components/Footer/SocialLinks/socialLinks.js
@@ -8,20 +8,18 @@ import PropTypes from "prop-types"
 export default function SocialLinks({ image, socialMedia }) {
   const logo = getImage(image?.localFile?.childImageSharp?.gatsbyImageData)
 
-  const socialMediaItems = socialMedia?.map(item => {
-    return (
-      <a
-        key={item.id}
-        href={item.url}
-        target="_blank"
-        className={`btn-social m-2 btn-social-icon btn-${item.icon?.name}`}
-        rel="noreferrer"
-        aria-label={`Link externo a ${item?.name}`}
-      >
-        <FaIcon type={item.icon?.type} code={item.icon?.code} />
-      </a>
-    )
-  })
+  const socialMediaItems = socialMedia?.map(item => (
+    <a
+      key={item.id}
+      href={item.url}
+      target="_blank"
+      className={`btn-social m-2 btn-social-icon btn-${item.icon?.name}`}
+      rel="noreferrer"
+      aria-label={`Link externo a ${item?.name}`}
+    >
+      <FaIcon type={item.icon?.type} code={item.icon?.code} />
+    </a>
+  ))
 
   return (
     <div className="Footer__socialMedia d-flex flex-column">
@@ -60,6 +58,9 @@ SocialLinks.propTypes = {
       url: PropTypes.string,
       name: PropTypes.string,
       icon: PropTypes.shape({
+        name: PropTypes.string,
+        type: PropTypes.string,
+        code: PropTypes.string,
         url: PropTypes.string,
         alternativeText: PropTypes.string,
         localFile: PropTypes.shape({


### PR DESCRIPTION
Se cambia el icono de Twitter por X.
FaIcon.jsx
Se eliminó el uso del ícono desactualizado fa-twitter.
Se agregó soporte para fa-x-twitter (nuevo logo de X) mediante importación directa desde @fortawesome/free-brands-svg-icons.
Se simplificó la lógica interna eliminando la condición especial para "fa-twitter" y usando un iconMap limpio y dinámico.
SocialLinks.jsx
Se eliminó la lógica condicional que interceptaba manualmente el código "fa-twitter" para renderizar el ícono de X con FontAwesomeIcon.
SocialLinks delega completamente la responsabilidad de renderizado de íconos al componente FaIcon, manteniendo una mejor implementación.
Strapi (CMS)
Se actualizó el valor del campo code en la colección de íconos de redes sociales:
Ahora: "fa-x-twitter" → muestra correctamente el ícono moderno de X .

