### PR TITLE
SBIT-604 botón de twitter enlace sin texto de anclaje 

### DIFF
--- a/src/components/Footer/SocialLinks/socialLinks.js
+++ b/src/components/Footer/SocialLinks/socialLinks.js
@@ -17,7 +17,10 @@ export default function SocialLinks({ image, socialMedia }) {
       rel="noreferrer"
       aria-label={`Link externo a ${item?.name}`}
     >
-      <FaIcon type={item.icon?.type} code={item.icon?.code} />
+      <>
+        <FaIcon type={item.icon?.type} code={item.icon?.code} />
+        <span className="visually-hidden">Link a {item.name}</span>
+      </>
     </a>
   ))
 

--- a/src/components/Footer/SocialLinks/socialLinks.scss
+++ b/src/components/Footer/SocialLinks/socialLinks.scss
@@ -10,6 +10,9 @@
       color: $white;
       width: 21px;
       height: 21px;
+      display: inline-flex; // permite alinear mejor el ícono
+      align-items: center;
+      justify-content: center;
     }
   }
 
@@ -30,4 +33,17 @@
       object-fit: contain !important;
     }
   }
+}
+
+// Clase para ocultar texto visualmente pero mantenerlo accesible
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
 }

--- a/src/components/Footer/SocialLinks/socialLinks.scss
+++ b/src/components/Footer/SocialLinks/socialLinks.scss
@@ -10,7 +10,7 @@
       color: $white;
       width: 21px;
       height: 21px;
-      display: inline-flex; // permite alinear mejor el ícono
+      display: inline-flex; 
       align-items: center;
       justify-content: center;
     }
@@ -35,7 +35,6 @@
   }
 }
 
-// Clase para ocultar texto visualmente pero mantenerlo accesible
 .visually-hidden {
   position: absolute !important;
   width: 1px !important;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -269,3 +269,14 @@ body {
     font-size: 3em;
   }
 }
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
Se agregó un <span class="visually-hidden">Link a {nombre de red}</span> dentro de cada enlace social.
Se definió la clase .visually-hidden en global.scss para ocultar el texto visualmente pero mantenerlo accesible.
Se usó item.name para generar el texto dinámico (ej. “Link a Twitter”). Se hizo el cambio para todos los iconos, ya que si bien estaba reportdo solo para Twitter se presentaba el mismo error en los demas iconos.
El texto accesible ahora está presente en el DOM, no afecta el diseño y mejora la accesibilidad y el SEO. Se espera que el warning desaparezca en el próximo escaneo de Semrush.
